### PR TITLE
add testile_backup.json5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ world/serverconfig/*
 
 # add carpet.conf
 !world/carpet.conf
+
+!config/
+config/*
+!config/textile_backup.json5

--- a/config/textile_backup.json5
+++ b/config/textile_backup.json5
@@ -1,0 +1,109 @@
+{
+	/* 
+	   Should every world have its own backup folder?
+	*/
+	"perWorldBackup": true,
+	/* 
+	   Time between automatic backups in seconds
+	   When set to 0 backups will not be performed automatically
+	*/
+	"backupInterval": 3600,
+	/* 
+	   Delay in seconds between typing-in /backup restore and it actually starting
+	*/
+	"restoreDelay": 30,
+	/* 
+	   Should backups be done even if there are no players?
+	*/
+	"doBackupsOnEmptyServer": false,
+	/* 
+	   Should backup be made on server shutdown?
+	*/
+	"shutdownBackup": true,
+	/* 
+	   Should world be backed up before restoring a backup?
+	*/
+	"backupOldWorlds": true,
+	/* 
+	   A path to the backup folder
+	*/
+	"path": "backup/",
+	/* 
+	   This setting allows you to exclude files form being backed-up.
+	   Be very careful when setting it, as it is easy corrupt your world!
+	*/
+	"fileBlacklist": [],
+	/* 
+	   Should backups be deleted after being restored?
+	*/
+	"deleteOldBackupAfterRestore": true,
+	/* 
+	   Maximum number of backups to keep. If set to 0 then no backup will be deleted based their amount
+	*/
+	"backupsToKeep": 10,
+	/* 
+	   Maximum age of backups to keep in seconds.
+	    If set to 0 then backups will not be deleted based their age 
+	*/
+	"maxAge": 0,
+	/* 
+	   Maximum size of backup folder in kibi bytes (1024).
+	   If set to 0 then backups will not be deleted
+	*/
+	"maxSize": 0,
+	/* 
+	   Compression level 
+	   0 - 9
+	    Only affects zip compression.
+	*/
+	"compression": 7,
+	/* 
+	   Limit how many cores can be used for compression.
+	   0 means that all available cores will be used
+	*/
+	"compressionCoreCountLimit": 0,
+	/* 
+	   Available formats are:
+	   ZIP - normal zip archive using standard deflate compression
+	   GZIP - tar.gz using gzip compression
+	   TAR - .tar with no compression
+	*/
+	"format": "ZIP",
+	/* 
+	   Minimal permission level required to run commands
+	*/
+	"permissionLevel": 1,
+	/* 
+	   Player on singleplayer is always allowed to run command. Warning! On lan party everyone will be allowed to run it.
+	*/
+	"alwaysSingleplayerAllowed": true,
+	/* 
+	   Players allowed to run backup commands without sufficient permission level
+	*/
+	"playerWhitelist": [],
+	/* 
+	   Players banned from running backup commands besides their sufficient permission level
+	*/
+	"playerBlacklist": [],
+	/* 
+	   Announce to ALL players when backup starts
+	*/
+	"broadcastBackupStart": true,
+	/* 
+	   Announce to ALL players when backup finishes
+	*/
+	"broadcastBackupDone": true,
+	/* 
+	   Format of date&time used to name backup files.
+	   Remember not to use '#' symbol or any other character that is not allowed by your operating system such as:
+	   ':', '\', etc...
+	   For more info: https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
+	*/
+	"dateTimeFormat": "yyyy.MM.dd_HH-mm-ss",
+	/* 
+	   The Strict mode (default) aborts backup creation in case of any problem and deletes created files
+	   Permissible mode keeps partial/damaged backup but won't allow to restore it
+	   Very Permissible mode will skip the verification process. THIS MOST CERTAINLY WILL LEAD TO DATA LOSS OR CORRUPTION
+	*/
+	"integrityVerificationMode": "STRICT"
+}


### PR DESCRIPTION
加入了testile备份模组的备份配置
并启用了正常玩家都可以进行备份和恢复的功能:
位置在testtile_backup.json5:75行:
"permissionLevel":1,
添加这一功能可以在需要的时候及时恢复存档,这也是加入testile模组的初衷