### PR TITLE
Feature

### DIFF
--- a/config/textile_backup.json5
+++ b/config/textile_backup.json5
@@ -72,7 +72,7 @@
 	/* 
 	   Minimal permission level required to run commands
 	*/
-	"permissionLevel": 1,
+	"permissionLevel": 0,
 	/* 
 	   Player on singleplayer is always allowed to run command. Warning! On lan party everyone will be allowed to run it.
 	*/


### PR DESCRIPTION
更改/backup所需permissionlevel从1变为0
原因:发现变为0普通玩家才能用